### PR TITLE
Prettify tokens

### DIFF
--- a/src/Furigana.cpp
+++ b/src/Furigana.cpp
@@ -1,7 +1,6 @@
 
 #include <cstring>
 #include <algorithm>
-#include <string.h>
 
 #include "Furigana.h"
 #include "Utf8.h"

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1,0 +1,52 @@
+
+#include <string.h>
+
+#include "Parser.h"
+
+static std::string mecab_node_get_reading(const MeCab::Node *node) {
+#define MECAB_FEATURE_READING_FIELD 8
+    size_t field = 0;
+    char *token, *infos = strdupa(node->feature);
+
+    token = strtok(infos, ",");
+    while (token != NULL) {
+        field++;
+        if (field == MECAB_FEATURE_READING_FIELD) {
+            return std::string(token);
+        }
+        token = strtok(NULL, ",");
+    }
+    return "";
+}
+
+std::vector<std::pair<std::string, std::string> > Parser::tokenize(
+    char const *str
+) {
+    std::vector<std::pair<std::string, std::string> > tokens;
+    const MeCab::Node* node = this->tagger->parseToNode(str);
+    for (; node; node = node->next) {
+        if (node->stat != MECAB_BOS_NODE && node->stat != MECAB_EOS_NODE) {
+            std::string token = std::string(node->surface, node->length);
+            std::string reading = std::string(mecab_node_get_reading(node));
+
+            tokens.push_back(std::pair<std::string, std::string>(
+                token,
+                reading
+            ));
+        }
+    }
+    return tokens;
+}
+
+Parser::Parser() {
+    wakatiTagger = MeCab::createTagger("-Owakati");
+    yomiTagger = MeCab::createTagger("-Oyomi");
+    tagger = MeCab::createTagger("");
+}
+
+Parser::~Parser() {
+    delete wakatiTagger;
+    delete yomiTagger;
+    delete tagger;
+}
+

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -3,15 +3,126 @@
 
 #include "Parser.h"
 
-static std::string mecab_node_get_reading(const MeCab::Node *node) {
-#define MECAB_FEATURE_READING_FIELD 8
+/* Some labels or other strings used in the IPA dictionary. */
+#define IPA_JOSHI "\u52a9\u8a5e" // 助詞
+#define IPA_SETSUZOKUJOSHI "\u63a5\u7d9a\u52a9\u8a5e" // 接続助詞
+#define IPA_BA "\u3070" // ば
+#define IPA_TE "\u3066" // て
+#define IPA_U "\u3046" // う
+#define IPA_N "\u3093" // ん
+#define IPA_FUHENKAKEI "\u4e0d\u5909\u5316\u578b" // 不変化型
+#define IPA_JODOUSHI "\u52a9\u52d5\u8a5e" // 助動詞
+#define IPA_TOKUSHU_NAI "\u7279\u6b8a\u30fb\u30ca\u30a4" // 特殊・ナイ
+#define IPA_TOKUSHU_TA "\u7279\u6b8a\u30fb\u30bf" // 特殊・タ
+#define IPA_TOKUSHU_TAI "\u7279\u6b8a\u30fb\u30bf\u30a4" // 特殊・タイ
+#define IPA_TOKUSHU_MASU "\u7279\u6b8a\u30fb\u30de\u30b9" // 特殊・マス
+#define IPA_TOKUSHU_NU "\u7279\u6b8a\u30fb\u30cc" // 特殊・ヌ
+#define IPA_DOUSHI "\u52d5\u8a5e" // 動詞
+#define IPA_SETSUBI "\u63a5\u5c3e" // 接尾
+#define IPA_HIJIRITSU "\u975e\u81ea\u7acb" // 非自立
+
+/* Number of comma-separated fields in the IPA dictionary. */
+#define IPA_FEATURE_FIELDS 7
+
+/* Number of the reading field in the IPA dictionary. */
+#define IPA_FEATURE_READING_FIELD 8
+
+/**
+ * Parse the given comma-separated string into the provided array of strings.
+ * "foo,bar,baz" → [ "foo", "bar", "baz" ]
+ */
+static void parse_feature(
+    const char *feature,
+    std::string (&parsed_feature)[IPA_FEATURE_FIELDS]
+) {
+    char *token, *infos = strdupa(feature);
+
+    int i = 0;
+    token = strtok(infos, ",");
+    while (token != NULL && i < IPA_FEATURE_FIELDS) {
+        parsed_feature[i].assign(token);
+        i++;
+        token = strtok(NULL, ",");
+    }
+}
+
+/**
+ * Check if the given parsed_feature matches against the given pattern.
+ */
+static bool pattern_match(
+    std::string parsed_feature[IPA_FEATURE_FIELDS],
+    std::string pattern[IPA_FEATURE_FIELDS]
+) {
+    for (int i = 0; i < IPA_FEATURE_FIELDS; i++) {
+        if (!pattern[i].empty() && parsed_feature[i] != pattern[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Check if the given feature (dictionary entry of a token)
+ * should be merged with the preceding token.
+ */
+static bool is_mergeable_token(const char *feature) {
+    /* A list of verb conjugation or suffixes patterns we'd like to keep
+     * with the root. An empty string "" means wildcard. */
+    static std::string ipa_merge_patterns[][IPA_FEATURE_FIELDS] = {
+        /* 食べれ.ば */
+        { IPA_JOSHI, IPA_SETSUZOKUJOSHI, "", "", "", "", IPA_BA },
+        /* 食べ.て */
+        { IPA_JOSHI, IPA_SETSUZOKUJOSHI, "", "", "", "", IPA_TE },
+        /* 食べろ.う */
+        { IPA_JODOUSHI, "", "", "", IPA_FUHENKAKEI, "", IPA_U },
+        /* 食べませ.ん */
+        { IPA_JODOUSHI, "", "", "", IPA_FUHENKAKEI, "", IPA_N },
+        /* 食べ.ない */
+        { IPA_JODOUSHI, "", "", "", IPA_TOKUSHU_NAI, "", "" },
+        /* 食べ.たい */
+        { IPA_JODOUSHI, "", "", "", IPA_TOKUSHU_TAI, "", "" },
+        /* 食べ.ます */
+        { IPA_JODOUSHI, "", "", "", IPA_TOKUSHU_MASU, "", "" },
+        /* 変わら.ぬ */
+        { IPA_JODOUSHI, "", "", "", IPA_TOKUSHU_NU, "", "" },
+        /* 食べ.た, 食べ.たら */
+        { IPA_JODOUSHI, "", "", "", IPA_TOKUSHU_TA, "", "" },
+        /* Lots of verb suffixes like 食べ.られる, 食べ.させる,
+         * 食べ.させて, さ.れる */
+        { IPA_DOUSHI, IPA_SETSUBI, "", "", "", "", "" },
+        /* Lots of -te verb suffixes like 食べ.ちゃう,
+         * 食べて.いる/ある/くれる/もらう/あげる/やる/みる/しまう/
+         *        いけない/なさい/おく,
+         * and 食べなければ.ならない... */
+        { IPA_DOUSHI, IPA_HIJIRITSU, "", "", "", "", "" }
+    };
+
+    std::string parsed_feature[IPA_FEATURE_FIELDS] = { "" };
+
+    parse_feature(feature, parsed_feature);
+
+    for (int i = 0; i < sizeof(ipa_merge_patterns)/sizeof(*ipa_merge_patterns); i++) {
+        if (pattern_match(parsed_feature, ipa_merge_patterns[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Return the wanted_field'th field of the feature of the given node.
+ */
+static std::string mecab_node_get_field(
+    const MeCab::Node *node,
+    int wanted_field
+) {
     size_t field = 0;
     char *token, *infos = strdupa(node->feature);
 
     token = strtok(infos, ",");
     while (token != NULL) {
         field++;
-        if (field == MECAB_FEATURE_READING_FIELD) {
+        if (field == wanted_field) {
             return std::string(token);
         }
         token = strtok(NULL, ",");
@@ -19,6 +130,25 @@ static std::string mecab_node_get_reading(const MeCab::Node *node) {
     return "";
 }
 
+/**
+ * Return the reading field of the given node (assuming IPA dictionary).
+ */
+static std::string mecab_node_get_reading(const MeCab::Node *node) {
+    return mecab_node_get_field(node, IPA_FEATURE_READING_FIELD);
+}
+
+/**
+ * Tokenize the given string into a list of (writing, reading) pairs,
+ * for instance "私はここにいる。" should returns:
+ * (
+ *   ("私",   "わたし"),
+ *   ("は",   "は"),
+ *   ("ここ", "ここ"),
+ *   ("に",   "に"),
+ *   ("いる", "いる"),
+ *   ("。",   "。")
+ * )
+ */
 std::vector<std::pair<std::string, std::string> > Parser::tokenize(
     char const *str
 ) {
@@ -28,6 +158,14 @@ std::vector<std::pair<std::string, std::string> > Parser::tokenize(
         if (node->stat != MECAB_BOS_NODE && node->stat != MECAB_EOS_NODE) {
             std::string token = std::string(node->surface, node->length);
             std::string reading = std::string(mecab_node_get_reading(node));
+
+            if (tokens.size() > 0 && is_mergeable_token(node->feature)) {
+                std::string prev_token = std::string(tokens.back().first);
+                token.assign(prev_token + token);
+                std::string prev_reading = std::string(tokens.back().second);
+                reading.assign(prev_reading + reading);
+                tokens.pop_back();
+            }
 
             tokens.push_back(std::pair<std::string, std::string>(
                 token,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1,0 +1,33 @@
+#ifndef SINOPARSER_PARSER_H
+#define SINOPARSER_PARSER_H
+
+#include <mecab.h>
+#include <string>
+#include <vector>
+
+#include "Furigana.h"
+
+namespace MeCab {
+    class Tagger;
+}
+
+
+class Parser {
+
+    private:
+        MeCab::Tagger* wakatiTagger;
+        MeCab::Tagger* tagger;
+
+    public:
+        Furigana furigana;
+        std::vector<std::pair<std::string, std::string> > tokenize(char const *str);
+        Parser();
+        ~Parser();
+
+        // TODO move to private
+        MeCab::Tagger* yomiTagger;
+};
+
+
+#endif
+

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -75,10 +75,6 @@ inline static void token_output_xml(const char *token, struct evbuffer *buffer) 
     evbuffer_add_printf(buffer, "]]></token>\n");
 }
 
-
-
-
-
 /**
  *
  */
@@ -261,10 +257,6 @@ static void http_furigana_callback(struct evhttp_request *request, void *data) {
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
 }
-
-
-
-
 
 /**
  *

--- a/src/Server.h
+++ b/src/Server.h
@@ -1,7 +1,7 @@
 #ifndef SINOPARSER_SERVER_H
 #define SINOPARSER_SERVER_H
 
-#include "Furigana.h"
+#include "Parser.h"
 
 #include <iostream>
 
@@ -11,16 +11,9 @@ namespace MeCab {
 
 
 class Server {
-
     public:
-        // TODO : I know it's bad, shame on me
-        MeCab::Tagger* wakatiTagger;
-        MeCab::Tagger* yomiTagger;
-        MeCab::Tagger* tagger;
-        Furigana furigana;
-
+        Parser parser;
         Server(std::string address, int port);
-        ~Server();
 };
 
 


### PR DESCRIPTION
This PR actually does two things:
* Separate Server.cpp into Server.cpp and Parser.cpp, keeping parser-related functions separate and abstracted.
* Prettify tokenization of verbs by merging root and varying part (e.g. 食べます instead of 食べ + ます. Such break-down greatly helps parsers to do their job, but makes reading of the tokenized text mode difficult for humans and less straightforward.
